### PR TITLE
Upgraded peer dependency @curveball/core.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
-    "@curveball/core": "^0.15.0"
+    "@curveball/core": ">=0.16 <1"
   },
   "types": "dist/",
   "nyc": {


### PR DESCRIPTION
Hello. Is this package intentionally dependent on an older version of `core`? I've lightly tested with 0.16.2 and it seems to be working fine (on serverless local, anyway).